### PR TITLE
codeblock: Change html to text codeblock so that pre and code tags

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,7 +91,7 @@ app.get('/', function(req, res){
 ## 7. Create Views
 
 Loop through `assets_url` in `home.handlebars` to render the thumbnails of product images. For simplicity in this example we do not use a database to store rows of product information. But you may store the image url from this array into your products schema if needed.
-```html
+```text
 <!-- Page Features -->
 <div class="row text-center">
 	{{#each url}}


### PR DESCRIPTION
Code and Pre tags have to get generated from markdown to html. This change is done at Atul's request to change it to text instead of html.
