### PR TITLE
Update Bucket Policy Example

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ Make a bucket called `minio-store` on play.minio.io. Use `mc mb` command to acco
 2. Store product image assets can be set to public readwrite. Use `mc policy` command to set the access policy on this bucket to "both". More details on the `mc policy` command can be found [here](https://docs.minio.io/docs/minio-client-complete-guide#policy).
 
    ```sh
-    mc policy both play/minio-store
+    mc policy public play/minio-store
    ```
 
 3. Upload store product pictures into this bucket.  Use `mc cp`  command to do this. More details on the `mc cp` command can be found [here](https://docs.minio.io/docs/minio-client-complete-guide#cp).


### PR DESCRIPTION
Both is no longer a bucket policy which is supported by mc, change to public which is the modern equivalent